### PR TITLE
Append Discord display name of author when sending message from Discord to game

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,7 +83,7 @@ int main() {
 		if (event.msg.channel_id == FDR::config.msg_channel) {
 			if(FDR::config.allow_achievements) {
 				// ID here doesn't matter really, we're not wanting a response.
-				rcon_client.send_data(event.msg.content, 999, rconpp::data_type::SERVERDATA_EXECCOMMAND);
+				rcon_client.send_data("«" + event.msg.author.global_name + "»: " + event.msg.content, 999, rconpp::data_type::SERVERDATA_EXECCOMMAND);
 			} else {
 				rcon_client.send_data("/silent-command game.print(\"[Discord] " + event.msg.author.username + " » " + event.msg.content + "\")", 999, rconpp::data_type::SERVERDATA_EXECCOMMAND);
 			}


### PR DESCRIPTION
It was kinda annoying that when achievements were off and when relaying a message from Discord to Factorio, we can't see the author of that message on the game since it only says `<server>: ...`. This PR fixes this issue.

How relayed messages looked like before this PR:
![image](https://github.com/user-attachments/assets/8b292e6e-8fad-4ea5-9bc9-54b361dbb427)


After this PR:
![image](https://github.com/user-attachments/assets/b8fef4d6-ea53-44aa-935e-d101b619298b)


- [x] My PR is titled using the [convention commits style](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I tested my changes before raising the PR.
- [x] I have not built my pull request using AI, a static analysis tool, or similar, without any human oversight.